### PR TITLE
Merge PR7 improvements without losing features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,5 +99,7 @@ exclude = "src/oceandata|ocean_sdk|scripts|tests"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = "tests.*"disallow_untyped_defs = false
+module = "tests.*"
+disallow_untyped_defs = false
 disallow_incomplete_defs = false
+

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import pandas as pd
 import typer
 from dotenv import load_dotenv
-from rich import print
 from rich.progress import Progress
 
 from ocean_sdk import (
@@ -32,13 +31,13 @@ def main(
     """OceanData CLI entry point."""
     ctx.obj = {"DEBUG": debug}
     if debug:
-        print("[bold blue]Debug mode activated[/bold blue]")
+        typer.echo("Debug mode activated")
 
 
 @app.command()
 def hello(name: str = "World") -> None:
     """Simple greeting."""
-    print(f"[green]Hello, {name}![/green]")
+    typer.echo(f"Hello, {name}!")
 
 
 @app.command(name="add")
@@ -49,7 +48,7 @@ def add_cmd(x: float, y: float) -> None:
         result = int(result)
     a = int(x) if float(x).is_integer() else x
     b = int(y) if float(y).is_integer() else y
-    print(f"[cyan]{a} + {b} = {result}[/cyan]")
+    typer.echo(f"{a} + {b} = {result}")
 
 
 @app.command()
@@ -57,42 +56,42 @@ def analyze(source_type: str) -> None:
     """Run analysis for the given data source using dummy data."""
     data = pd.DataFrame()
     result = run_analysis(data, source_type)
-    print(result)
+    typer.echo(result)
 
 
 @app.command()
 def publish(name: str, price: float) -> None:
     """Publish a dataset via the blockchain helper."""
     result = publish_dataset(name, {"title": name}, price)
-    print(result)
+    typer.echo(result)
 
 
 @app.command()
 def train(data_id: str) -> None:
     """Trigger Compute-to-Data training for a dataset."""
     result = train_model(data_id)
-    print(result)
+    typer.echo(result)
 
 
 @app.command()
 def sync() -> None:
     """Synchronize with the marketplace backend."""
     result = sync_marketplace()
-    print(result)
+    typer.echo(result)
 
 
 @app.command()
 def whoami() -> None:
     """Display current user identity."""
     identity = get_user_identity()
-    print(identity.model_dump())
+    typer.echo(identity.model_dump())
 
 
 @app.command()
 def register(name: str, schema: str, version: str) -> None:
     """Register a model."""
     info = register_model(name, schema, version)
-    print(info.model_dump())
+    typer.echo(info.model_dump())
 
 
 @app.command()
@@ -102,7 +101,7 @@ def evaluate(model_id: str, dataset_id: str) -> None:
         task = progress.add_task("evaluating", total=1)
         result = evaluate_model(model_id, dataset_id)
         progress.update(task, advance=1)
-    print(result.model_dump())
+    typer.echo(result.model_dump())
 
 
 @app.command()
@@ -110,9 +109,9 @@ def results(model_id: str) -> None:
     """Retrieve evaluation outputs."""
     try:
         result = retrieve_model_outputs(model_id)
-        print(result.model_dump())
+        typer.echo(result.model_dump())
     except KeyError:
-        print(f"[red]No results for model {model_id}[/red]")
+        typer.echo(f"No results for model {model_id}")
 
 
 def cli_main() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,33 +4,26 @@ from __future__ import annotations
 
 from typer.testing import CliRunner
 from pathlib import Path
-import importlib.util
 import sys
 import ast
 
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-main_path = ROOT / "src" / "main.py"
-spec = importlib.util.spec_from_file_location("cli_main", main_path)
-main = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(main)
-app = main.app
+from src.main import app
 
 
 def test_hello_command() -> None:
     runner = CliRunner()
     result = runner.invoke(app, ["hello"])
     assert result.exit_code == 0
-    assert "Hello" in result.output
+    assert "Hello, World!" in result.output
 
 
 def test_add_command() -> None:
     runner = CliRunner()
     result = runner.invoke(app, ["add", "2", "3"])
     assert result.exit_code == 0
-    assert "= 5" in result.output
+    assert "2 + 3 = 5" in result.output
 
 
 def test_sync_command() -> None:

--- a/ts-sdk/src/index.ts
+++ b/ts-sdk/src/index.ts
@@ -1,1 +1,51 @@
 export * from './core';
+
+/** OceanData TypeScript SDK */
+
+export interface PublishOptions {
+  metadata: Record<string, any>;
+  price: number;
+  files?: Array<Record<string, any>>;
+  config?: Record<string, any>;
+}
+
+/**
+ * Publish a dataset to the OceanData marketplace.
+ *
+ * @remarks
+ * This placeholder simply returns the provided metadata.
+ */
+export async function publishDataset(name: string, options: PublishOptions): Promise<Record<string, any>> {
+  return {
+    success: true,
+    name,
+    metadata: options.metadata,
+    price: options.price,
+    files: options.files ?? [],
+  };
+}
+
+/**
+ * Execute an analysis job.
+ *
+ * @param data - Input data
+ * @param sourceType - Identifier of the data source
+ */
+export async function runAnalysis(data: unknown, sourceType: string): Promise<Record<string, unknown>> {
+  return { sourceType, recordCount: Array.isArray(data) ? data.length : 0 };
+}
+
+/**
+ * Retrieve results for a previously submitted job.
+ */
+export async function fetchResults(jobId: string): Promise<Record<string, any>> {
+  return { jobId, status: 'done', result: null };
+}
+
+/**
+ * Get current marketplace listings.
+ */
+export async function getMarketplaceListings(): Promise<Array<Record<string, any>>> {
+  return [];
+}
+


### PR DESCRIPTION
## Summary
- preserve features while applying lint fixes
- fix mypy configuration
- use `typer.echo` in CLI instead of `rich.print`
- simplify CLI tests and keep coverage of advanced commands
- expand TS SDK exports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e76c21ac88324a8f99dec8a0a5e30